### PR TITLE
Override removeAllViews to avoid pager from adding new views while unmouting.

### DIFF
--- a/android/src/main/java/is/uncommon/rn/widgets/TabbedViewPager.java
+++ b/android/src/main/java/is/uncommon/rn/widgets/TabbedViewPager.java
@@ -86,6 +86,10 @@ public class TabbedViewPager extends LinearLayout {
     this.reactViewPager.removeViewFromAdapter(index);
   }
 
+  public void removeAllViewsFromAdapter() {
+    this.reactViewPager.removeAllViewsFromAdapter();
+  }
+
   public void setPageMargin(int i) {
     this.reactViewPager.setPageMargin(i);
   }

--- a/android/src/main/java/is/uncommon/rn/widgets/TabbedViewPagerManager.java
+++ b/android/src/main/java/is/uncommon/rn/widgets/TabbedViewPagerManager.java
@@ -149,6 +149,10 @@ import javax.annotation.Nullable;
     parent.removeViewFromAdapter(index);
   }
 
+  @Override public void removeAllViews(TabbedViewPager parent) {
+    parent.removeAllViewsFromAdapter();
+  }
+
   @ReactProp(name = "pageMargin", defaultFloat = 0)
   public void setPageMargin(TabbedViewPager pager, float margin) {
     pager.setPageMargin((int) PixelUtil.toPixelFromDIP(margin));


### PR DESCRIPTION
The default ViewManager implementation of removeAllViews iterates over all existing children and calls removeViewAt(index) method. When this happens the ViewPager implementation triggers a code path that adds new tab views (the path starts from calling notifyDatasetChanged in ReactViewPager.java which ends up triggering TabLayout view updates that clean up all the views and add individual tabs from scratch https://android.googlesource.com/platform/frameworks/support/+/5c7d7bb/design/src/android/support/design/widget/TabLayout.java#616).

Apparently when using libraries that provides Android's native transition (e.g. react-native-screens v2) it is undesirable for the views being unmounted to remove and then add back children. It is because these libraries rely on a mechanism called view transitions which prevents children from being removed so long the transition is ongoing. As a result the children removed in TabLayout implementation does not go through the complete removal cycle and they cannot be added back because they are not yet unmounted. This cased a crash documented here https://github.com/kmagiera/react-native-screens/issues/153#issuecomment-544142132